### PR TITLE
Restore the README hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+![CutDirector 顶部横幅](assets/hero.png)
+
 # CutDirector
 
 **专为已拍口播视频设计的 ChatCut 口播导演 Skill**


### PR DESCRIPTION
## What changed

- restore `assets/hero.png` at the top of the README
- keep the existing image unchanged for now

## Why

The repository should continue showing its visual hero while a CutDirector-branded replacement is prepared.

## Checks

- confirmed `assets/hero.png` exists and is tracked
- `git diff --check` passed
