### PR TITLE
fix: unify Prompt 005 preview style

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@
 
 [观看 Prompt 004 演示视频](assets/verified-prompts/prompt-004-top-chapter-progress-rail.mp4) · [查看完整说明](references/prompt-004-top-chapter-progress-rail.md)
 
-### Prompt 005 · Page Waterfall Wall 斜向卡片滚动
+### Prompt 005 · 斜向卡片滚动
 
-[![Prompt 005 - 官网原始 Page Waterfall Wall 斜向卡片滚动](assets/verified-prompts/prompt-005-diagonal-card-waterfall.gif)](assets/verified-prompts/prompt-005-diagonal-card-waterfall.mp4)
+[![Prompt 005 - 斜向卡片滚动](assets/verified-prompts/prompt-005-diagonal-card-waterfall.gif)](assets/verified-prompts/prompt-005-diagonal-card-waterfall.mp4)
 
 **快速使用**
 


### PR DESCRIPTION
## 修正内容

- 将 Prompt 005 的 GIF 预览从 `480×270` 恢复为 `960×540`，与 Prompt 001/002 的展示宽度一致。
- README 标题统一为中文 `Prompt 005 · 斜向卡片滚动`。
- 同步精简图片替代文字，保持系列命名一致。

## 根因

为绕过首次上传时的连接重置，Prompt 005 的 GIF 曾被过度压缩到 480 像素宽。GitHub Markdown 按图片固有尺寸展示，因此该案例在 README 中只有其他案例约一半宽。

## 验证

- GIF：`960×540`、8fps
- `py -3 scripts\validate_talkdirector.py`
- `py -3 -m unittest tests.test_talkdirector_pipeline tests.test_sync_chatcut_prompt_library tests.test_generate_visual_gallery -v`
- `git diff --check`

19 项测试全部通过。