### PR TITLE
feat: add finished-video workflow skill

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -39,6 +39,7 @@ licensed under the Creative Commons Attribution-ShareAlike 4.0 International
 license (`CC BY-SA 4.0`). This includes:
 
 - `SKILL.md`
+- `skills/**`
 - `recipes/**`
 - original material in `README.md`
 - original CutDirector material in `references/**`

--- a/README.md
+++ b/README.md
@@ -282,6 +282,31 @@
 
 后续案例只在真实时间线中完成并通过验证后，才会加入这个系列。
 
+## 配套成片工作流
+
+CutDirector 现在把能力分成两层：
+
+| 层级 | 负责什么 | 典型交付 |
+| --- | --- | --- |
+| **局部 Prompt** | 解决一个镜头、一个信息结构或一种局部剪辑效果 | Logo 弹出、双栏讲解、章节进度条 |
+| **成品级 Skill** | 编排多个步骤和局部 Prompt，负责从选题到发布包的完整结果 | 成片、封面、投稿信息、来源清单 |
+
+仓库同时提供第一个成品级 [`daily-info-gap-video`](skills/daily-info-gap-video/SKILL.md) Skill，用于把当天热点直接做成可发布的中文信息差视频。它负责热点核验与去重、先看素材再写稿、视频优先、成片节奏、配音、字幕、顶部进度条、双比例封面、4K 导出和投稿信息；“AI每日大事”是其中一个预设。
+
+成品级 Skill 可以按需调用仓库里的局部 Prompt，但完成一个局部 Prompt 不代表成片已经完成。
+
+单独安装：
+
+```text
+$skill-installer install https://github.com/Fangx-AI/cut-director/tree/main/skills/daily-info-gap-video
+```
+
+安装后可以直接说：
+
+```text
+使用 $daily-info-gap-video 制作今天的 AI 每日大事，控制在 90 秒，直接交付成片、两张封面和投稿信息。
+```
+
 ## 30 秒开始
 
 ### 1. 安装 Skill

--- a/skills/daily-info-gap-video/SKILL.md
+++ b/skills/daily-info-gap-video/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: daily-info-gap-video
+description: Produce a finished Chinese daily information-gap or news-recap video from current hot topics, including research, deduplication, material-first scripting, ChatCut editing, energetic narration, subtitles, a segmented top progress bar, covers, 4K export, and posting copy. Use for requests such as “做今天的AI每日大事”, “做一期90秒科技信息差”, “把今日热点剪成成片”, or recurring daily news-video production.
+---
+
+# Daily Info Gap Video
+
+Create the complete publish-ready package, not just a topic list or script. Treat “AI每日大事” as one preset of a reusable workflow that can also cover technology, business, products, finance, and other daily information-gap topics.
+
+This is an end-to-end finished-video Skill. Treat CutDirector’s verified Prompts as optional shot-level building blocks: a Prompt solves one local viewing or editing task, while this Skill owns the whole episode from topic selection through export and delivery. Never mistake successful execution of one Prompt for completion of the video.
+
+## Load the production rules
+
+Always read:
+
+- `references/editorial-rules.md`
+- `references/production-spec.md`
+- `references/cover-and-delivery.md`
+
+Also read `references/ai-daily-preset.md` when the subject is AI or the user asks for “AI每日大事”.
+
+For an editable ChatCut project, invoke `chatcut:chatcut-plugin-basics` first, then use the relevant ChatCut skills for asset import, transcription, voice, motion graphics, verification, image/video generation, and export. Follow each invoked skill exactly.
+
+## Defaults
+
+Unless the user overrides them:
+
+- Language and audience: Simplified Chinese, mainland general audience
+- Format: 16:9 landscape
+- Duration: about 90 seconds; fit the story count to the day rather than forcing five items
+- Opening line: `90秒看完今日{主题}大事`
+- Narration: `liuchang`, bright, high-energy, confident technology-news delivery for the entire episode
+- Export: highest practical quality, target 4K
+- Covers: one 4:3 landscape image and one 3:4 portrait image
+- Publishing: prepare a semi-automatic handoff; do not submit the final platform post without explicit authorization
+
+Ask a question only when a missing choice would materially change the result. Otherwise state the assumption and continue.
+
+## Workflow
+
+### 1. Set the episode brief
+
+Resolve the date, subject, target platform, approximate duration, prior-episode cutoff, and delivery folder. If the user supplied a hot-list page or source feed, use it as the candidate pool rather than as the sole authority.
+
+### 2. Research and select stories
+
+Browse current sources because daily news is time-sensitive. Verify each candidate against the original announcement or another authoritative source whenever possible.
+
+Build a compact candidate ledger containing:
+
+- event and source
+- publication/event time
+- heat or corroboration count
+- why a general viewer should care
+- duplicate cluster and prior-episode status
+- available real video, images, or generated-material need
+
+Remove repeated events and near-duplicates. Prefer stories that are fresh, widely discussed, consequential, understandable, and visually expressible. Select the natural number of worthwhile stories, normally three to seven.
+
+### 3. Acquire and inspect materials before writing
+
+Create a shot ledger per story. Use this priority:
+
+1. Relevant real video
+2. Relevant real image
+3. Generated video or image only when necessary
+
+Inspect every video clip before scripting: identify what it visibly proves, usable time ranges, shot changes, logos/text, resolution, and whether its pacing supports narration. Never write claims that the available visuals cannot support.
+
+Do not reuse the same shot or materially identical image in separate timeline positions unless the repetition is an explicit recap. Track asset IDs and source URLs to enforce this.
+
+### 4. Write to the edit
+
+Write a beat sheet that maps each narration clause to an exact visual. Start with the opening promise, then move immediately into the first story’s visual as soon as the first story is mentioned.
+
+The copy must explain the public-facing consequence before technical parameters. Use concrete language, tension, comparison, surprise, and “why it matters”; avoid reading specifications, corporate phrasing, and rigid “第一条、第二条” enumeration.
+
+Keep narration nearly continuous. Rewrite, tighten visuals, or add a short connective line if a silent gap would exceed about 0.5 seconds outside an intentional pause.
+
+### 5. Build the editable video
+
+Create or update the ChatCut project:
+
+- place narration first and cut visuals to its semantic beats
+- use actual video whenever available
+- add readable Chinese subtitles
+- add the persistent segmented top progress bar described in `references/production-spec.md`
+- use restrained transitions that preserve momentum
+- keep all on-screen microcopy Chinese unless a proper noun requires English
+- keep music and effects below narration
+
+Generate missing media only after real-media options are exhausted. Generated clips must be clearly aligned with the spoken claim and must not impersonate documentary evidence.
+
+### 6. Create covers and posting package
+
+Generate both cover ratios from the same visual identity and episode hook. Use the fixed prompt framework in `references/cover-and-delivery.md`, changing only the date, theme, hero subject, and short hook.
+
+Prepare title, description, tags, source notes, and any AI-content declaration. Keep titles curiosity-driven but factually defensible.
+
+### 7. Verify and export
+
+Watch the full timeline and verify:
+
+- story and visual start on the same beat
+- no duplicate footage
+- narration stays bright and energetic throughout
+- no unexplained long silence
+- captions are accurate and readable
+- the top bar fills smoothly and its segment boundaries match the edit
+- no unsupported claims or stale/repeated stories
+- cover text is legible at thumbnail size
+
+Export the final video and package it with both covers and posting metadata in the dated folder. Report exact clickable file paths.
+
+## Typical triggers
+
+- “生成今天的AI大事90秒视频”
+- “从这个热榜挑最值得讲的几件事，直接做成片”
+- “做一期面向大众的科技信息差，不要堆参数”
+- “沿用昨天的风格，但不要重复昨天的事情和素材”

--- a/skills/daily-info-gap-video/agents/openai.yaml
+++ b/skills/daily-info-gap-video/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "每日信息差视频"
+  short_description: "从热点筛选到4K成片交付的中文每日信息差视频工作流"
+  brand_color: "#FF5A36"
+  default_prompt: "Use $daily-info-gap-video to produce a 90-second Chinese information-gap video with covers and posting copy."

--- a/skills/daily-info-gap-video/references/ai-daily-preset.md
+++ b/skills/daily-info-gap-video/references/ai-daily-preset.md
@@ -1,0 +1,43 @@
+# AI每日大事 preset
+
+Use this preset when the subject is AI news.
+
+## Sources and selection
+
+Start from the user’s provided AI hot list, including AIHOT when requested, then verify the final stories with primary sources such as company announcements, product documentation, research papers, repositories, regulator notices, or direct statements.
+
+Prefer:
+
+- major model or product launches with visible user impact
+- widely discussed safety, security, policy, or platform events
+- meaningful business moves that change the AI landscape
+- demos that make an abstract capability easy to understand
+- developments likely to affect Chinese creators, developers, companies, or consumers
+
+Do not fill the episode with benchmark deltas, token counts, funding figures, or capital-expenditure numbers. Mention a number only after explaining what it changes in ordinary language.
+
+## Established format
+
+- Spoken opener: `90秒看完今日AI大事`
+- Opening screen: show only that recurring promise and the date/brand; do not show the first story headline
+- As soon as the narration names the first company or model, cut to its relevant video
+- Story count varies with the day
+- Narration stays bright, high-energy, and technology-news-like from the first syllable to the final line
+- Use the `liuchang` female voice unless overridden
+- Keep speech nearly continuous
+- Real product/event video first; image second; generated material last
+- Never repeat the same source shot
+- Chinese subtitles throughout
+- Persistent top segmented progress bar with dynamic story labels
+- Export a 4K landscape video plus 4:3 and 3:4 covers into one dated folder
+
+## Audience framing
+
+Translate technical news into:
+
+- what viewers can do now that they could not do before
+- what becomes cheaper, faster, easier, riskier, or more competitive
+- who is likely to benefit or lose
+- what deserves skepticism
+
+Avoid an insider-only tone. Explain one necessary technical term at most per sentence, using an immediate example or analogy.

--- a/skills/daily-info-gap-video/references/cover-and-delivery.md
+++ b/skills/daily-info-gap-video/references/cover-and-delivery.md
@@ -1,0 +1,56 @@
+# Cover and delivery
+
+## Fixed cover prompt framework
+
+Keep the identity stable across days while varying the episode subject.
+
+Prompt:
+
+> 为中文短视频栏目“每日信息差”制作高记忆点科技新闻封面。深海军蓝到黑色背景，强烈橙红警报色与电光青点缀；左侧或中央放置一个具有固定栏目辨识度的橙色未来感“情报侦察球”机器人，单眼雷达镜头发出青色扫描光，电影级3D硬表面细节，强轮廓光，速度感与紧迫感。画面保留清晰的大标题安全区，主标题为“{HOOK}”，副标可为“今日速报”，角落显示日期“{DATE}”和栏目名“每日信息差”。围绕当天主题“{THEME}”加入一个明确但不杂乱的英雄视觉“{HERO_SUBJECT}”。中文排版巨大、粗壮、短促，缩略图尺寸仍清楚；不要小英文、不要密集参数、不要复杂信息图、不要水印、不要平台UI。商业科技媒体封面，强对比，高点击但不夸大事实。
+
+Generate two independent compositions from the same identity:
+
+- 4:3 landscape: hero visual and title can share left/right weight
+- 3:4 portrait: stack hero and title vertically; keep the main title inside the central safe area
+
+Do not merely crop one ratio into the other. Inspect both images for malformed Chinese text; if text quality is unreliable, generate the clean visual background and add exact text in the editor.
+
+## Hook rules
+
+- Keep the main cover hook short, ideally 6–12 Chinese characters
+- Promise speed, consequence, surprise, or relevance
+- Do not list every story
+- Do not claim a fixed story count unless the episode actually contains it
+- The recurring spoken opener may remain `90秒看完今日{主题}大事`; the cover hook can feature the strongest verified tension of the day
+
+## Delivery folder
+
+Use:
+
+`{workspace}/{YYYY-MM-DD}/`
+
+Recommended contents:
+
+- `每日信息差_{YYYY-MM-DD}_4K.mp4`
+- `每日信息差_{YYYY-MM-DD}_封面_4比3.png`
+- `每日信息差_{YYYY-MM-DD}_封面_3比4.png`
+- `投稿信息.md`
+- optional `来源与素材清单.md`
+
+For an AI preset, keeping the established `AI每日大事_...` filename prefix is acceptable.
+
+## 投稿信息.md
+
+Include:
+
+- recommended title and two alternatives
+- platform category
+- tags
+- concise description
+- AI-generated-content declaration when applicable
+- story list with primary source URLs
+- material credits or license notes
+- final video duration and resolution
+- any uncertainty or manual checks still required
+
+Prepare the upload package automatically. Stop before final publication unless the user explicitly authorizes that platform action.

--- a/skills/daily-info-gap-video/references/editorial-rules.md
+++ b/skills/daily-info-gap-video/references/editorial-rules.md
@@ -1,0 +1,60 @@
+# Editorial rules
+
+## Candidate scoring
+
+Score candidates with judgment rather than a fake precise formula. Favor:
+
+- Freshness: happened or materially advanced within the episode window
+- Heat: multiple credible sources, strong platform discussion, or an official release with immediate impact
+- Public relevance: changes what ordinary people can use, buy, fear, expect, or talk about
+- Consequence: affects products, jobs, creators, markets, safety, or daily behavior
+- Visual potential: has usable video, demos, charts, screenshots, people, or before/after evidence
+- Distinctness: adds a new theme rather than repeating another item
+
+Reject rumors without sufficient evidence, minor parameter updates with no public consequence, and stories already covered without a meaningful new development.
+
+## Deduplication
+
+Cluster candidates by underlying event, not headline wording. Treat follow-up articles, reposts, reactions, and translated coverage as one story unless there is a genuinely new development.
+
+Before selecting, inspect the most recent dated delivery folders or prior episode metadata when available. Maintain a short list of:
+
+- covered event
+- covered date
+- what changed since then
+
+Only repeat an event when the new change can be stated in one clear sentence.
+
+## Story framing
+
+For each selected story, answer:
+
+1. What happened?
+2. Why is it surprising or important now?
+3. What changes for an ordinary viewer?
+4. What is still uncertain?
+
+Open with the consequence or tension. Put necessary names and parameters after the viewer understands why they matter.
+
+Weak:
+
+> 某模型上下文提升到一百万，基准测试提高百分之十二。
+
+Better:
+
+> 过去要拆成几十次处理的长文档，现在可能一次就能读完；背后是上下文容量的大幅提升，但真实效果还要看落地。
+
+## Script rhythm
+
+- Opening promise: roughly 1–2 seconds
+- Each story: usually 10–20 seconds, adjusted to importance and available visuals
+- One spoken idea per visual beat
+- Prefer short sentences and active verbs
+- Use transitions that create momentum: “更值得注意的是…”, “真正影响普通人的，是…”, “另一边…”
+- Do not announce “第一条、第二条”
+- Do not repeat the headline as both title card and narration
+- End with a concise takeaway or anticipation, not a generic slogan
+
+## Truth and sourcing
+
+Use primary sources where possible. Distinguish announced, demonstrated, reported, alleged, and independently verified facts. Avoid turning generated visuals into evidence. Preserve source URLs in the delivery notes even when they are not shown on screen.

--- a/skills/daily-info-gap-video/references/production-spec.md
+++ b/skills/daily-info-gap-video/references/production-spec.md
@@ -1,0 +1,70 @@
+# Production specification
+
+## Visual system
+
+- Default canvas: 16:9 landscape
+- Target export: 3840×2160 when source and tool limits allow
+- Chinese-first labels; retain English only for proper nouns, logos, and product names
+- Use a consistent dark technology-news palette with one warm alert accent and one cool information accent unless the user supplies a brand system
+- Keep the first frame simple: the opening promise only, without the first story headline
+
+## Material priority and uniqueness
+
+Use real video before images. Use images before generated media. Crop and animate images only when it adds readable motion, not to disguise lack of footage.
+
+Assign every placed asset a unique ledger ID. Before final export, compare adjacent and non-adjacent shots for identical frames, repeated source clips, repeated screenshots, and near-identical crops. Replace accidental repeats.
+
+When the narration first names a person, company, model, product, or event, the picture must already show that subject or an unmistakably relevant visual.
+
+## Narration
+
+- Default voice: `liuchang`
+- Delivery: bright, upbeat, high-energy, confident, quick but intelligible technology bulletin
+- Maintain the same energy through every story and the ending
+- Do not use a low, sentimental, sleepy, solemn, or documentary-style opening
+- Avoid silent gaps longer than about 0.5 seconds, except a deliberate beat no longer than about 0.8 seconds
+- Use short pickup lines or visual compression rather than padding with empty music
+
+Listen to the rendered audio, not only the TTS prompt. Regenerate any line whose actual delivery drops in energy.
+
+## Subtitles
+
+- Burn in Simplified Chinese subtitles unless the user requests a separate subtitle file
+- Keep each subtitle to one or two short lines
+- Break by meaning, not fixed character count
+- High contrast with a subtle stroke or background plate
+- Keep subtitles clear of the top progress bar and platform UI-safe edges
+- Verify names, model numbers, dates, and punctuation manually
+
+## Segmented top progress bar
+
+Create one persistent horizontal navigation strip at the very top of the frame. It represents the whole video, not only the current story.
+
+Structure:
+
+- left cap: `片头`
+- one dynamic segment per selected story, labeled with a concise Chinese topic
+- right cap: `片尾`
+- a thin active fill line advances continuously from 0% at video start to 100% at video end
+- the active story segment receives a restrained highlight
+
+Rules:
+
+- Derive labels and segment durations from the final timeline; never hard-code five stories
+- Segment widths should roughly reflect actual story durations while remaining legible
+- Progress must be driven by global timeline time, not reset for each story
+- Keep the bar within the top safe area and small enough not to cover key footage
+- Use Chinese labels whenever possible
+- Motion must be smooth and deterministic
+- If a story is removed or reordered, regenerate both labels and timing
+
+## Transitions and sound
+
+- Prefer direct cuts, short directional wipes, scale/position matches, and brief graphic bridges
+- Avoid decorative transitions that delay the next visual
+- Background music should add urgency without masking consonants
+- Use sound effects sparingly for the opening, section changes, and progress milestones
+
+## Final watch checklist
+
+Watch once for story logic, once for picture/audio sync, and once at thumbnail/mobile scale. Check the first five seconds separately because retention is most fragile there.


### PR DESCRIPTION
## 变更内容

- 新增独立的 `skills/daily-info-gap-video` 成品级 Skill
- 固化热点核验与去重、素材优先级、先识别素材再写稿、成片节奏、全程高昂配音、字幕、动态顶部进度条、双比例封面、4K 导出与投稿信息交付
- 提供 `AI每日大事` 预设，同时保留科技、商业、产品等其他信息差主题的复用能力
- 在 README 中明确两层能力架构：Prompt 是镜头级局部积木，成品级 Skill 负责端到端编排
- 将 `skills/**` 纳入项目的原创内容许可范围

## 为什么

现有 Verified Prompts 适合解决单个镜头或局部信息结构，但每日信息差视频需要从选题到发布包的完整工作流。这个 Skill 将已经验证过的生产规则固化成可重复执行的成品流程，同时继续按需复用局部 Prompt。

## 用户影响

用户可直接要求制作当日信息差视频，并获得可编辑成片、双比例封面和投稿信息，而不是只得到文案或单个局部效果。

## 校验

- `quick_validate.py skills/daily-info-gap-video`：通过
- `quick_validate.py .`：通过
- `git diff --check`：通过